### PR TITLE
Ensure callbacks are called even if the pool does not exist

### DIFF
--- a/index.js
+++ b/index.js
@@ -147,13 +147,15 @@ var newest_idx = function newest_idx(pool, callback) {
   var child = spawn_process('p-newest-idx ' + pool);
   if (!child) return null;
 
+  var index = -1;
   child.stdout.setEncoding('utf8');
   child.stdout.on('data', function(data) {
-    try {
-      callback(parseInt(data));
-    } catch (e) {
-      console.log(e);
-    }
+    index = parseInt(data);
+    if(index === undefined)
+      index = -1;
+  });
+  child.stdout.on('end', function() {
+    callback(index);
   });
   return child;
 };
@@ -166,13 +168,15 @@ var oldest_idx = function oldest_idx(pool, callback) {
   var child = spawn_process('p-oldest-idx ' + pool);
   if (!child) return null;
 
+  var index = -1;
   child.stdout.setEncoding('utf8');
   child.stdout.on('data', function(data) {
-    try {
-      callback(parseInt(data));
-    } catch (e) {
-      console.log(e);
-    }
+    index = parseInt(data);
+    if(index === undefined)
+      index = -1;
+  });
+  child.stdout.on('end', function() {
+    callback(index);
   });
   return child;
 };
@@ -198,6 +202,7 @@ var process_protein = function process_protein(protein, callback) {
   } catch (e) {
     console.log('Yaml error handling protein: ' + JSON.stringify(e));
   }
+  callback(null);
   return false;
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -93,6 +93,24 @@ describe('peek', function () {
     after(function() { child.kill(); });
   });
 
+  it('returns null for oldest when pool does not exist', function (done) {
+    var child = plas.oldest('fubar', function (p) {
+      assert.equal(p, null);
+      done();
+    });
+
+    after(function() { child.kill(); });
+  });
+
+  it('returns null for newest when pool does not exist', function (done) {
+    var child = plas.newest('fubar', function (p) {
+      assert.equal(p, null);
+      done();
+    });
+
+    after(function() { child.kill(); });
+  });
+
 });
 
 describe('indices', function () {
@@ -127,6 +145,24 @@ describe('indices', function () {
   it('identifies oldest index', function (done) {
     var child = plas.oldestIndex('baz', function (i) {
       assert.equal(i, 0);
+      done();
+    });
+
+    after(function() { child.kill(); });
+  });
+
+  it('returns -1 for newestIndex when pool does not exist', function (done) {
+    var child = plas.newestIndex('fubar', function (i) {
+      assert.equal(i, -1);
+      done();
+    });
+
+    after(function() { child.kill(); });
+  });
+
+  it('returns -1 for oldestIndex when pool does not exist', function (done) {
+    var child = plas.oldestIndex('fubar', function (i) {
+      assert.equal(i, -1);
       done();
     });
 


### PR DESCRIPTION
This change ensures that the callbacks for oldest/newest return null,
and oldestIndex/newestIndex return -1, if the pool does not exist, or
the command otherwise fails (security reasons, etc.).