### PR TITLE
Fix `process_protein` to only call the callback once

### DIFF
--- a/index.js
+++ b/index.js
@@ -185,7 +185,7 @@ var oldest_idx = function oldest_idx(pool, callback) {
 //
 // Returns a bool to indicate whether parsing was successful
 var process_protein = function process_protein(protein, callback) {
-  var callbackCalled = false;
+  var success = false;
   try {
     yaml.safeLoadAll(protein, function(protein) {
       if (protein.descrips && protein.ingests && protein.descrips.length > 0) {
@@ -194,7 +194,7 @@ var process_protein = function process_protein(protein, callback) {
         } catch (e) {
           console.log(e);
         }
-        callbackCalled = true;
+        success = true;
       } else {
         console.log('ERROR: protein arrived without descrips or ingests: ');
         console.log(JSON.stringify(protein));
@@ -204,9 +204,11 @@ var process_protein = function process_protein(protein, callback) {
     console.log('Yaml error handling protein: ' + JSON.stringify(e));
   }
 
-  if (!callbackCalled) {
+  if (!success) {
     callback(null);
   }
+
+  return success;
 }
 
 exports.poke = poke;

--- a/index.js
+++ b/index.js
@@ -185,6 +185,7 @@ var oldest_idx = function oldest_idx(pool, callback) {
 //
 // Returns a bool to indicate whether parsing was successful
 var process_protein = function process_protein(protein, callback) {
+  var callbackCalled = false;
   try {
     yaml.safeLoadAll(protein, function(protein) {
       if (protein.descrips && protein.ingests && protein.descrips.length > 0) {
@@ -193,7 +194,7 @@ var process_protein = function process_protein(protein, callback) {
         } catch (e) {
           console.log(e);
         }
-        return true;
+        callbackCalled = true;
       } else {
         console.log('ERROR: protein arrived without descrips or ingests: ');
         console.log(JSON.stringify(protein));
@@ -202,8 +203,10 @@ var process_protein = function process_protein(protein, callback) {
   } catch (e) {
     console.log('Yaml error handling protein: ' + JSON.stringify(e));
   }
-  callback(null);
-  return false;
+
+  if (!callbackCalled) {
+    callback(null);
+  }
 }
 
 exports.poke = poke;


### PR DESCRIPTION
There was a logic error in `process_protein` that was causing the
callback to be called twice. In a previous patch, the function was
augmented to call `callback(null)` when the protein couldn't be parsed
properly. This is reasonable, but `callback(null)` was being executed
even after a successful `callback(protein)`, because of where the
`callback(null)` was (after the `catch` block.