### PR TITLE
support 2-, 3-, and 4-vects

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ var SlawYamlType = new yaml.Type('tag:oblong.com,2009:slaw/protein', {
 var VectYamlType = new yaml.Type('tag:oblong.com,2009:slaw/vector', {
   kind: 'sequence',
   resolve: function (data) {
-    return data !== null && data.length === 3;
+    return data !== null && data.length >= 2 && data.length <= 4;
   },
   construct: function (data) {
     return new types.Vect(data);

--- a/test/index.js
+++ b/test/index.js
@@ -185,18 +185,27 @@ describe('custom types', function () {
   // splitting out a private module for the YAML encoding/decoding and testing
   // that would be a good idae.
   var Vect = plas.types.Vect;
-  var loc = new Vect([0.0, -1.0, 2.0]);
+  var v2 = new Vect([0.0, -1.0]);
+  var v3 = new Vect([0.0, -1.0, 2.0]);
+  var v4 = new Vect([0.0, -1.0, 2.0, 3.0]);
 
-  it('after poking a Vect, peeks back a Vect', function (done) {
+  it('after poking an n-Vect, peeks back an n-Vect', function (done) {
     var VECT_POOL = 'pjsb-vect';
     empty_pool(VECT_POOL);
     var pokeAsync = promisify(plas.poke);
-    pokeAsync(['loctest'], {loc: loc}, VECT_POOL)
+    pokeAsync(['vect-test'], {v2: v2, v3: v3, v4: v4}, VECT_POOL)
       .then(function () {
         plas.oldest(VECT_POOL, function (protein) {
-          assert.deepEqual(protein.descrips, ['loctest']);
-          assert.instanceOf(protein.ingests['loc'], Vect);
-          assert.deepEqual(protein.ingests['loc'], loc);
+          assert.deepEqual(protein.descrips, ['vect-test']);
+
+          assert.instanceOf(protein.ingests['v2'], Vect);
+          assert.deepEqual(protein.ingests['v2'], v2);
+
+          assert.instanceOf(protein.ingests['v3'], Vect);
+          assert.deepEqual(protein.ingests['v3'], v3);
+
+          assert.instanceOf(protein.ingests['v4'], Vect);
+          assert.deepEqual(protein.ingests['v4'], v4);
           done();
         });
       });

--- a/test/index.js
+++ b/test/index.js
@@ -189,11 +189,13 @@ describe('custom types', function () {
   var v3 = new Vect([0.0, -1.0, 2.0]);
   var v4 = new Vect([0.0, -1.0, 2.0, 3.0]);
 
+  var VECT_POOL = 'pjsb-vect';
+
   it('after poking an n-Vect, peeks back an n-Vect', function (done) {
-    var VECT_POOL = 'pjsb-vect';
-    empty_pool(VECT_POOL);
-    var pokeAsync = promisify(plas.poke);
-    pokeAsync(['vect-test'], {v2: v2, v3: v3, v4: v4}, VECT_POOL)
+    empty_pool(VECT_POOL)
+      .then (function () {
+        return pokeAsync(['vect-test'], {v2: v2, v3: v3, v4: v4}, VECT_POOL);
+      })
       .then(function () {
         plas.oldest(VECT_POOL, function (protein) {
           assert.deepEqual(protein.descrips, ['vect-test']);
@@ -206,6 +208,34 @@ describe('custom types', function () {
 
           assert.instanceOf(protein.ingests['v4'], Vect);
           assert.deepEqual(protein.ingests['v4'], v4);
+          done();
+        });
+      });
+  })
+
+  it('array-style accessors are provided for backwards compat.', function (done) {
+    empty_pool(VECT_POOL)
+      .then (function () {
+        return pokeAsync(['vect-test'], {v2: v2, v3: v3, v4: v4}, VECT_POOL);
+      })
+      .then(function () {
+        plas.oldest(VECT_POOL, function (protein) {
+          assert.deepEqual(protein.descrips, ['vect-test']);
+
+          assert.instanceOf(protein.ingests['v2'], Vect);
+          assert.equal(protein.ingests['v2'][0], v2.x);
+          assert.equal(protein.ingests['v2'][1], v2.y);
+
+          assert.instanceOf(protein.ingests['v3'], Vect);
+          assert.equal(protein.ingests['v3'][0], v3.x);
+          assert.equal(protein.ingests['v3'][1], v3.y);
+          assert.equal(protein.ingests['v3'][2], v3.z);
+
+          assert.instanceOf(protein.ingests['v4'], Vect);
+          assert.equal(protein.ingests['v4'][0], v4.x);
+          assert.equal(protein.ingests['v4'][1], v4.y);
+          assert.equal(protein.ingests['v4'][2], v4.z);
+          assert.equal(protein.ingests['v4'][3], v4.w);
           done();
         });
       });

--- a/types.js
+++ b/types.js
@@ -2,17 +2,28 @@
 
 'use strict';
 
+// Constructs a 2-, 3-, or 4- vect from the specified components, or an
+// array of the corresponding length. Read-only array-style accessors
+// (e.g. v[0]) are provided for backwards compatibility.
 function Vect(x, y, z, w) {
   if (Array.isArray(x)) {
     this.x = x[0];
     this.y = x[1];
     this.z = x[2];
     this.w = x[3];
+    this[0] = x[0];
+    this[1] = x[1];
+    this[2] = x[2];
+    this[3] = x[3];
   } else {
     this.x = x;
     this.y = y;
     this.z = z;
     this.w = w;
+    this[0] = x;
+    this[1] = y;
+    this[2] = z;
+    this[3] = w;
   }
 }
 

--- a/types.js
+++ b/types.js
@@ -2,20 +2,27 @@
 
 'use strict';
 
-function Vect(x, y, z) {
+function Vect(x, y, z, w) {
   if (Array.isArray(x)) {
     this.x = x[0];
     this.y = x[1];
     this.z = x[2];
+    this.w = x[3];
   } else {
     this.x = x;
     this.y = y;
     this.z = z;
+    this.w = w;
   }
 }
 
 Vect.prototype.toArray = function toArray() {
-  return [this.x, this.y, this.z];
+  if (this.w !== undefined)
+    return [this.x, this.y, this.z, this.w];
+  if (this.z !== undefined)
+    return [this.x, this.y, this.z];
+  else
+    return [this.x, this.y];
 };
 
 exports.Vect = Vect;


### PR DESCRIPTION
Extending @tomjakubowski's support for vects with 2 and 4 component versions. 2-vects are often used in 2D coordinate spaces, and 4-vects are sometimes used for colors, e.g. RGBA.