### PR TITLE
Teach JS-YAML about slaw/array

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,21 @@ var VectYamlType = new yaml.Type('tag:oblong.com,2009:slaw/vector', {
   }
 });
 
-var SLAW_SCHEMA = yaml.Schema.create([SlawYamlType, VectYamlType]);
+var ArrayYamlType = new yaml.Type('tag:oblong.com,2009:slaw/array', {
+  kind: 'sequence',
+  resolve: function (data) {
+    return Array.isArray(data);
+  },
+  construct: function (data) {
+    return new types.Array(data);
+  },
+  'instanceOf': types.Array,
+  represent: function (array) {
+    return array.toArray();
+  }
+});
+
+var SLAW_SCHEMA = yaml.Schema.create([SlawYamlType, VectYamlType, ArrayYamlType]);
 
 var spawn_process = function spawn_process(cmd, args) {
   var child = spawn(cmd, args);

--- a/test/index.js
+++ b/test/index.js
@@ -188,16 +188,18 @@ describe('custom types', function () {
   var v2 = new Vect([0.0, -1.0]);
   var v3 = new Vect([0.0, -1.0, 2.0]);
   var v4 = new Vect([0.0, -1.0, 2.0, 3.0]);
+  var Arr = plas.types.Array;
+  var a1 = new Arr([0.0, -1.0]);
 
-  var VECT_POOL = 'pjsb-vect';
+  var TYPES_POOL = 'pjsb-vect';
 
   it('after poking an n-Vect, peeks back an n-Vect', function (done) {
-    empty_pool(VECT_POOL)
+    empty_pool(TYPES_POOL)
       .then (function () {
-        return pokeAsync(['vect-test'], {v2: v2, v3: v3, v4: v4}, VECT_POOL);
+        return pokeAsync(['vect-test'], {v2: v2, v3: v3, v4: v4}, TYPES_POOL);
       })
       .then(function () {
-        plas.oldest(VECT_POOL, function (protein) {
+        plas.oldest(TYPES_POOL, function (protein) {
           assert.deepEqual(protein.descrips, ['vect-test']);
 
           assert.instanceOf(protein.ingests['v2'], Vect);
@@ -214,12 +216,12 @@ describe('custom types', function () {
   })
 
   it('array-style accessors are provided for backwards compat.', function (done) {
-    empty_pool(VECT_POOL)
+    empty_pool(TYPES_POOL)
       .then (function () {
-        return pokeAsync(['vect-test'], {v2: v2, v3: v3, v4: v4}, VECT_POOL);
+        return pokeAsync(['vect-test'], {v2: v2, v3: v3, v4: v4}, TYPES_POOL);
       })
       .then(function () {
-        plas.oldest(VECT_POOL, function (protein) {
+        plas.oldest(TYPES_POOL, function (protein) {
           assert.deepEqual(protein.descrips, ['vect-test']);
 
           assert.instanceOf(protein.ingests['v2'], Vect);
@@ -236,6 +238,22 @@ describe('custom types', function () {
           assert.equal(protein.ingests['v4'][1], v4.y);
           assert.equal(protein.ingests['v4'][2], v4.z);
           assert.equal(protein.ingests['v4'][3], v4.w);
+          done();
+        });
+      });
+  })
+
+  it('after poking a SlawArray, peeks back a SlawArray', function (done) {
+    empty_pool(TYPES_POOL)
+      .then (function () {
+        return pokeAsync(['array-test'], {'slawArray': a1}, TYPES_POOL);
+      })
+      .then(function () {
+        plas.oldest(TYPES_POOL, function (protein) {
+          assert.deepEqual(protein.descrips, ['array-test']);
+
+          assert.instanceOf(protein.ingests['slawArray'], Arr);
+          assert.deepEqual(protein.ingests['slawArray'], a1);
           done();
         });
       });

--- a/types.js
+++ b/types.js
@@ -36,4 +36,13 @@ Vect.prototype.toArray = function toArray() {
     return [this.x, this.y];
 };
 
+function SlawArray(arr) {
+  this._arr = arr || [];
+}
+
+SlawArray.prototype.toArray = function toArray() {
+  return this._arr.slice();
+}
+
 exports.Vect = Vect;
+exports.Array = SlawArray;


### PR DESCRIPTION
Allows read/write of of slaw/array in the same way as slaw/vector.

Resolves issue #17